### PR TITLE
Print input/output files

### DIFF
--- a/scripts/gwf
+++ b/scripts/gwf
@@ -25,7 +25,7 @@ parser = argparse.ArgumentParser(
     For questions, comments or bug-reports contact <mailund@birc.au.dk> or go to https://github.com/mailund/gwf/issues/
     """)
 
-parser.add_argument('-f', '--file', 
+parser.add_argument('-f', '--file',
                     default='workflow.py', dest='workflow_file',
                     help='Workflow file if not the default (workflow.py).')
 parser.add_argument('-d', '--dry-run', default=False, action='store_true',
@@ -68,18 +68,18 @@ if args.performance:
     if os.path.isfile('.jobs.ids'):
 
         with open('.jobs.ids', 'r') as job_file:
-            
+
             finished_jobs = []
             unfinished_jobs = []
 
             for line in job_file:
-                
+
                 job_id, job_name = line.split()
-                
+
                 # Get job info provided by SLURM.
                 job_info    = subprocess.check_output('jobinfo {job_id}'.format(job_id=job_id), shell=True)
                 state       = re.search(r'^State *: (.*)', job_info, re.MULTILINE).group(1).strip()
-                
+
                 if state == 'COMPLETED':
 
                     # Grab various information from SLURM job status.
@@ -108,18 +108,18 @@ if args.performance:
                 else:
 
                     unfinished_jobs.append((job_id, state, job_name))
-        
+
         if len(finished_jobs) > 0:
 
-            # Print header line.            
+            # Print header line.
             print '{:>8} {:>6} {:>6} {:>14} {:>14} {:>16} {:>16} {:>16} {:>19}  {}'.format(
                   'job_id', 'nodes', 'cores', 'used_walltime', 'used_cpu_time','max_memory_used',
                   'memory_reserved', 'cpu_performance', 'memory_performance', 'name')
 
             for job in finished_jobs:
-                
+
                 print '{job_id:>8} {nodes:>6} {cores:>6} {used_walltime:>14} {used_cpu_time:>14} {max_memory_used:>16} {memory_reserved:>16} {cpu_performance:>16} {memory_performance:>19}  {job_name}'.format(
-                
+
                     # Print information from SLURM job info.
                     job_id          = job['id'],
                     nodes           = job['nodes'],
@@ -133,12 +133,12 @@ if args.performance:
                     # Calculate performace based on values above.
                     cpu_performance     = job_cpu_performance(job),
                     memory_performance  = job_memory_performace(job)
-                
+
                 )
 
         # Print list of jobs not completed (for whatever reason).
         if len(unfinished_jobs) > 0:
-            
+
             print
 
             max_state_length = 0
@@ -167,7 +167,7 @@ if args.clean:
     else:
         for target in args.targets:
             workflow.targets[target].clean_target()
-        
+
     sys.exit(0)
 
 if len(args.targets) > 0:

--- a/scripts/gwf
+++ b/scripts/gwf
@@ -273,7 +273,7 @@ else:
         for job in schedule:
 
             if job.job_id:
-                print "Taget", job.target.name, "is already submitted ({})".format(job.job_id)
+                print "Target", job.target.name, "is already submitted ({})".format(job.job_id)
                 continue
 
             dependents = [dependent for dependent in job.depends_on if dependent.target.name in scheduled_jobs]

--- a/scripts/gwf
+++ b/scripts/gwf
@@ -270,6 +270,16 @@ else:
             continue
 
         print '{}Scheduling computation of target'.format(COLORS['bold']), target_name, '{}...'.format(CLEAR)
+        if args.verbose:
+            target = workflow.targets[target_name]
+            print 'Inputs'
+            for name in target.target.options['input']:
+                print '   ', os.path.relpath(name)
+            print 'Outputs'
+            for name in target.target.options['output']:
+                print '   ', os.path.relpath(name)
+            print
+
         for job in schedule:
 
             if job.job_id:


### PR DESCRIPTION
When `--verbose` is enabled, prints the input and output files of each target when submitted. Maybe this should be a separate command like `gwf --targets`. Useful for debugging.