### PR TITLE
Alternative syntax for target options

### DIFF
--- a/examples/minimal-workflow/workflow.py
+++ b/examples/minimal-workflow/workflow.py
@@ -1,23 +1,29 @@
-from gwf import Workflow
+from gwf import *
 
 gwf = Workflow()
 
-gwf.target('SayHello', inputs=['name.txt'], outputs=['greeting.txt']) << """
+gwf.target('SayHello') << inputs('name.txt') << outputs('greeting.txt') << """
 echo -n "Hello " > greeting.txt
 cat name.txt >> greeting.txt
 """
 
-gwf.target("World", inputs=['greeting.txt'], outputs=['world.txt']) << """
+gwf.target("World") << inputs('greeting.txt') << outputs('world.txt') << """
 cat greeting.txt > world.txt
 echo "world" >> world.txt
 """
 
-gwf.target("Universe", inputs=['greeting.txt'], outputs=['universe.txt']) << """
+gwf.target("Universe") <<\
+    inputs('greeting.txt') <<\
+    outputs('universe.txt') <<\
+"""
 cat greeting.txt > universe.txt
 echo "universe" >> universe.txt
 """
 
-gwf.target("All", inputs=['world.txt', 'universe.txt'], outputs=['all.txt']) << """
+gwf.target("All") <<\
+    inputs('world.txt', 'universe.txt') <<\
+    outputs('all.txt') <<\
+"""
 cat world.txt > all.txt
 cat universe.txt >> all.txt
 """

--- a/gwf/__init__.py
+++ b/gwf/__init__.py
@@ -5,7 +5,7 @@ __version__ = get_versions()['version']
 del get_versions
 
 from gwf.core import PreparedWorkflow, Target, Workflow  # noqa: E402
-from gwf.core import inputs, outputs  # noqa: E402
+from gwf.core import inputs, outputs, options  # noqa: E402
 
 USER_CONFIG_FILE = os.path.expanduser('~/.gwf.conf')
 LOCAL_CONFIG_FILE = '.gwf.conf'
@@ -45,4 +45,4 @@ class template(object):
 
 
 __all__ = ('Target', 'Workflow', 'PreparedWorkflow', 'template',
-           'inputs', 'outputs')
+           'inputs', 'outputs', 'options')

--- a/gwf/__init__.py
+++ b/gwf/__init__.py
@@ -5,6 +5,7 @@ __version__ = get_versions()['version']
 del get_versions
 
 from gwf.core import PreparedWorkflow, Target, Workflow  # noqa: E402
+from gwf.core import inputs, outputs  # noqa: E402
 
 USER_CONFIG_FILE = os.path.expanduser('~/.gwf.conf')
 LOCAL_CONFIG_FILE = '.gwf.conf'
@@ -43,4 +44,5 @@ class template(object):
             self.__class__.__name__, self.options, self.spec)
 
 
-__all__ = ('Target', 'Workflow', 'PreparedWorkflow', 'template',)
+__all__ = ('Target', 'Workflow', 'PreparedWorkflow', 'template',
+           'inputs', 'outputs')

--- a/gwf/core.py
+++ b/gwf/core.py
@@ -14,7 +14,7 @@ from .events import post_schedule, pre_schedule
 from .exceptions import (CircularDependencyError,
                          FileProvidedByMultipleTargetsError,
                          FileRequiredButNotProvidedError, IncludeWorkflowError,
-                         InvalidNameError, TargetExistsError, InvalidTypeError)
+                         InvalidNameError, TargetExistsError)
 from .utils import (cache, dfs, get_file_timestamp, import_object,
                     is_valid_name, iter_inputs, iter_outputs, merge, timer)
 
@@ -543,8 +543,7 @@ class PreparedWorkflow(object):
             if target.is_sink and target.warn_sink:
                 logging.warning(
                     ('Target %s declares no outputs. If this is intentional, '
-                     'set the option sink() for the target.'),
-                     target.name)
+                     'set the option sink() for the target.'), target.name)
 
     @cache
     def should_run(self, target):

--- a/gwf/core.py
+++ b/gwf/core.py
@@ -14,7 +14,7 @@ from .events import post_schedule, pre_schedule
 from .exceptions import (CircularDependencyError,
                          FileProvidedByMultipleTargetsError,
                          FileRequiredButNotProvidedError, IncludeWorkflowError,
-                         InvalidNameError, TargetExistsError, InvalidTypeError)
+                         InvalidNameError, TargetExistsError)
 from .utils import (cache, dfs, get_file_timestamp, import_object,
                     is_valid_name, iter_inputs, iter_outputs, merge, timer)
 

--- a/gwf/core.py
+++ b/gwf/core.py
@@ -63,7 +63,6 @@ def normalized_paths_property(name):
 
 class TargetOption(object):
     """Abstract class working as a tag for target options."""
-    pass
 
     def update_target(self, target):
         """The method used to update a target with options."""

--- a/gwf/core.py
+++ b/gwf/core.py
@@ -90,6 +90,21 @@ class outputs(TargetOption):
         target.outputs = self.outputs
 
 
+class options(TargetOption):
+    """Specifying a dictionary of options for a target.
+
+    These options are passed along to the backend. This is the most
+    general way of specifying options and the least safe. It is better
+    to use option-specific functions.
+    """
+
+    def __init__(self, **options):
+        self.options = options
+
+    def update_target(self, target):
+        target.options = self.options
+
+
 class Target(object):
     """Represents a target.
 
@@ -110,14 +125,14 @@ class Target(object):
     inputs = normalized_paths_property('inputs')
     outputs = normalized_paths_property('outputs')
 
-    def __init__(self, name, options, workflow, namespace=None, spec=''):
+    def __init__(self, name, workflow, namespace=None, spec=''):
         self.name = name
         if not is_valid_name(self.name):
             raise InvalidNameError(
                 'Target defined with invalid name: "{}".'.format(self.name)
             )
 
-        self.options = options
+        self.options = {}
         self.workflow = workflow
 
         self.inputs = []
@@ -225,7 +240,7 @@ class Workflow(object):
 
         self.targets[qualname] = target
 
-    def target(self, name, **options):
+    def target(self, name):
         """Create a target and add it to the :class:`gwf.Workflow`.
 
         This is syntactic sugar for creating a new :class:`~gwf.Target` and
@@ -247,13 +262,8 @@ class Workflow(object):
 
         :param str name: Name of the target.
 
-        Any further keyword arguments are passed to the backend.
         """
-
-        new_target = Target(
-            name, options, workflow=self
-        )
-
+        new_target = Target(name, workflow=self)
         self._add_target(new_target)
         return new_target
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from gwf import Target, Workflow
+from gwf import Target, Workflow, inputs, outputs
 
 
 class GWFTestCase(unittest.TestCase):
@@ -13,14 +13,20 @@ class GWFTestCase(unittest.TestCase):
         return thing
 
 
-def create_test_target(name='TestTarget', inputs=None, outputs=None, options=None, workflow=None):
+def create_test_target(name='TestTarget',
+                       input_files=None,
+                       output_files=None,
+                       options=None,
+                       workflow=None):
     """A factory for `Target` objects."""
-    if inputs is None:
-        inputs = []
-    if outputs is None:
-        outputs = []
+    if input_files is None:
+        input_files = []
+    if output_files is None:
+        output_files = []
     if options is None:
         options = {}
     if workflow is None:
         workflow = Workflow(working_dir='/some/path')
-    return Target(name, inputs, outputs, options, workflow)
+    target = Target(name, options, workflow)
+    target = target << inputs(*input_files) << outputs(*output_files)
+    return target

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from gwf import Target, Workflow, inputs, outputs
+from gwf import Target, Workflow, inputs, outputs, options
 
 
 class GWFTestCase(unittest.TestCase):
@@ -16,17 +16,18 @@ class GWFTestCase(unittest.TestCase):
 def create_test_target(name='TestTarget',
                        input_files=None,
                        output_files=None,
-                       options=None,
+                       opt=None,
                        workflow=None):
     """A factory for `Target` objects."""
     if input_files is None:
         input_files = []
     if output_files is None:
         output_files = []
-    if options is None:
-        options = {}
+    if opt is None:
+        opt = {}
     if workflow is None:
         workflow = Workflow(working_dir='/some/path')
-    target = Target(name, options, workflow)
-    target = target << inputs(*input_files) << outputs(*output_files)
-    return target
+    return Target(name, workflow) <<\
+        inputs(*input_files) <<\
+        outputs(*output_files) <<\
+        options(**opt)

--- a/tests/backends/test_slurm.py
+++ b/tests/backends/test_slurm.py
@@ -133,7 +133,7 @@ class TestSlurmBackendSubmit(SlurmTestCase):
         self.mock_get_live_job_states.return_value = {}
         self.mock_call_sbatch.return_value = ('1000', '')
 
-        target = self.workflow.target('TestTarget')
+        target = self.workflow.target('TestTarget') << sink()
         prepared_workflow = PreparedWorkflow(
             targets=self.workflow.targets,
             working_dir=self.workflow.working_dir,
@@ -199,7 +199,7 @@ class TestSlurmBackendCancel(SlurmTestCase):
         ]
         self.mock_get_live_job_states.return_value = {'1000': 'R'}
 
-        target = self.workflow.target('TestTarget')
+        target = self.workflow.target('TestTarget') << sink()
         prepared_workflow = PreparedWorkflow(
             targets=self.workflow.targets,
             working_dir=self.workflow.working_dir,
@@ -221,7 +221,7 @@ class TestSlurmBackendCancel(SlurmTestCase):
         ]
         self.mock_get_live_job_states.return_value = {}
 
-        target = self.workflow.target('TestTarget')
+        target = self.workflow.target('TestTarget') << sink()
         prepared_workflow = PreparedWorkflow(
             targets=self.workflow.targets,
             working_dir=self.workflow.working_dir,
@@ -246,8 +246,8 @@ class TestSlurmBackendSubmitted(SlurmTestCase):
         ]
         self.mock_get_live_job_states.return_value = {'1000': 'H'}
 
-        target1 = self.workflow.target('TestTarget1')
-        target2 = self.workflow.target('TestTarget2')
+        target1 = self.workflow.target('TestTarget1') << sink()
+        target2 = self.workflow.target('TestTarget2') << sink()
 
         prepared_workflow = PreparedWorkflow(
             targets=self.workflow.targets,
@@ -271,9 +271,9 @@ class TestSlurmBackendRunning(SlurmTestCase):
         ]
         self.mock_get_live_job_states.return_value = {'1000': 'R', '2000': 'H'}
 
-        target1 = self.workflow.target('TestTarget1')
-        target2 = self.workflow.target('TestTarget2')
-        target3 = self.workflow.target('TestTarget3')
+        target1 = self.workflow.target('TestTarget1') << sink()
+        target2 = self.workflow.target('TestTarget2') << sink()
+        target3 = self.workflow.target('TestTarget3') << sink()
 
         prepared_workflow = PreparedWorkflow(
             targets=self.workflow.targets,
@@ -292,7 +292,7 @@ class TestSlurmBackendRunning(SlurmTestCase):
 class TestSlurmBackendLogs(SlurmTestCase):
 
     def test_logs_raises_exception_target_has_no_log(self):
-        target = self.workflow.target('TestTarget')
+        target = self.workflow.target('TestTarget') << sink()
         prepared_workflow = PreparedWorkflow(
             targets=self.workflow.targets,
             working_dir=self.workflow.working_dir,
@@ -313,7 +313,7 @@ class TestSlurmBackendLogs(SlurmTestCase):
             '1000': 'R'
         }
 
-        target = self.workflow.target('TestTarget')
+        target = self.workflow.target('TestTarget') << sink()
         prepared_workflow = PreparedWorkflow(
             targets=self.workflow.targets,
             working_dir=self.workflow.working_dir,
@@ -338,7 +338,7 @@ class TestSlurmBackendLogs(SlurmTestCase):
             '1000': 'R'
         }
 
-        target = self.workflow.target('TestTarget')
+        target = self.workflow.target('TestTarget') << sink()
         prepared_workflow = PreparedWorkflow(
             targets=self.workflow.targets,
             working_dir=self.workflow.working_dir,

--- a/tests/backends/test_slurm.py
+++ b/tests/backends/test_slurm.py
@@ -2,7 +2,7 @@ import io
 import subprocess
 from unittest.mock import ANY, call, mock_open, patch
 
-from gwf import PreparedWorkflow, Target, Workflow
+from gwf import *
 from gwf.backends.slurm import (SlurmBackend, _call_sbatch, _call_scancel,
                                 _call_squeue, _dump_atomic, _find_exe,
                                 _get_live_job_states, _read_json)
@@ -106,19 +106,11 @@ class TestSlurmBackendSubmit(SlurmTestCase):
         self.mock_get_live_job_states.return_value = {'1000': 'R', '2000': 'H'}
         self.mock_call_sbatch.return_value = ('3000', '')
 
-        self.workflow.target(
-            'TestTarget1',
-            outputs=['test_output1.txt'],
-        )
-        self.workflow.target(
-            'TestTarget2',
-            outputs=['test_output2.txt']
-        )
-        target3 = self.workflow.target(
-            'TestTarget3',
-            inputs=['test_output1.txt', 'test_output2.txt'],
-            outputs=['test_output3.txt']
-        )
+        self.workflow.target('TestTarget1') << outputs('test_output1.txt')
+        self.workflow.target('TestTarget2') << outputs('test_output2.txt')
+        target3 = self.workflow.target('TestTarget3') <<\
+            inputs('test_output1.txt', 'test_output2.txt') <<\
+            outputs('test_output3.txt')
 
         backend = SlurmBackend()
         prepared_workflow = PreparedWorkflow(
@@ -172,8 +164,6 @@ class TestSlurmBackendSubmit(SlurmTestCase):
 
         target = Target(
             name='TestTarget',
-            inputs=[],
-            outputs=[],
             workflow=self.workflow,
             options={
                 'cores': 16,

--- a/tests/backends/test_slurm.py
+++ b/tests/backends/test_slurm.py
@@ -162,22 +162,12 @@ class TestSlurmBackendSubmit(SlurmTestCase):
         backend.configure(
             working_dir=prepared_workflow.working_dir, config=self.config)
 
-        target = Target(
-            name='TestTarget',
-            workflow=self.workflow,
-            options={
-                'cores': 16,
-                'memory': '16g',
-                'walltime': '12:00:00',
-                'queue': 'normal',
-                'account': 'someaccount',
-                'constraint': 'graphics*4',
-                'mail_type': 'BEGIN,END,FAIL',
-                'mail_user': 'test@domain.com',
-                'qos': 'somename',
-            },
-            spec='echo hello world'
-        )
+        target = Target(name='TestTarget', workflow=self.workflow) <<\
+            options(cores=16, memory='16g', walltime='12:00:00',
+                    queue='normal', account='someaccount',
+                    constraint='graphics*4', mail_type='BEGIN,END,FAIL',
+                    mail_user='test@domain.com', qos='somename') <<\
+            'echo hello world'
 
         script = backend._compile_script(target)
 


### PR DESCRIPTION
Change the syntax for passing options to targets. The keyword arguments method we use now makes it too easy to misspell arguments and, fx, not set input files by spelling "inputs" as "input" (quite likely, considering we have changed the argument name). The `target` method will accept all arguments and pass them on to the backend. Misspelling thus results in quiet errors.

With this PR, we no longer accept keyword arguments to `target`. Instead, options and files must be specified after targets are created. The syntax is similar to how we set specifications for targets, we use the `<<` operator.

I use classes to specify the various options that can be used here--they look like functions but they are classes since I need a method on them. I have only implemented classes for input and output files and a generic one for setting options. The latter, `options`, work the same way as `target` did before: it creates a dictionary with all the keyword arguments it gets.

You would specify a target with options like this:

``` python
gwf.target('SayHello') << inputs('name.txt') << outputs('greeting.txt') << options(cores=4) << """
echo -n "Hello " > greeting.txt
cat name.txt >> greeting.txt
"""
```

A better solution is to avoid these keyword arguments and make each option accepted by the backend an option class.

``` python
gwf.target('SayHello') << inputs('name.txt') << outputs('greeting.txt') << cores(4) << """
echo -n "Hello " > greeting.txt
cat name.txt >> greeting.txt
"""
```

If we do this, we can also check that options are set consistently before we submit jobs to the cluster.

A drawback of having functions/classes for the individual options, besides having to define them, is that it will be hard to write workflows that both check that options are valid and permit you to work with different backends. Either we need to restrict our options to a subset of options supported by all backends or we need a method of setting options without checking them.

Here, we can define some that have good defaults if they are not supported and otherwise maps to appropriate options for the backends -- options like number of cores or walltime -- and use the `options` function, knowing that it is unsafe, for options that are not necessarily available on all backends.
